### PR TITLE
🚑️ Fix duplicate message returning old message_id

### DIFF
--- a/services/validate_service.py
+++ b/services/validate_service.py
@@ -120,7 +120,7 @@ class ValidateService:
         TbSubjectService.update_last_sent_info(session, validate_req_dto, additional_field_dto.subject_id)
 
         return ValidateDto.ValidateResDto(
-            message_id = additional_field_dto.similar_id,
+            message_id = tb_ka_message.id,
             chat_id = validate_req_dto.chat_id,
             message = "Duplicate message",
             subject_id = additional_field_dto.subject_id


### PR DESCRIPTION
#9 PR 에서 완벽 일치하는 메세지도 -2로 변경하기로 했지만, 리턴하는 ID 값이 예전 message_id 로 되어서 이미지 매핑이 안되고 있습니다.
