### PR TITLE
Feature/add index on subject lastsent

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,16 @@ DB_PASSWORD=<your_db_password>
 DB_PORT=<your_db_port>  # Default is 3306
 ```
 
-### 4. Run the Server
+### 4. Apply DB migrations (First-time setup)
+If you’re setting up the project for the first time or on a new server, apply database schema via Alembic:
+
+```bash
+alembic upgrade head
+```
+This ensures all required tables and indexes are created based on migration history.
+
+
+### 5. Run the Server
 
 Once everything is set up, you can run the FastAPI server:
 

--- a/alembic/versions/ff1b46e7d6bd_add_index_to_subject_id_and_last_sent_.py
+++ b/alembic/versions/ff1b46e7d6bd_add_index_to_subject_id_and_last_sent_.py
@@ -1,0 +1,31 @@
+"""add index to subject_id and last_sent_at in tbkamessage
+
+Revision ID: ff1b46e7d6bd
+Revises: 347339a2659e
+Create Date: 2025-03-23 16:26:55.654956
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ff1b46e7d6bd'
+down_revision: Union[str, None] = '347339a2659e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    op.create_index(
+        'idx_ka_message_subject_sent',
+        'TbKaMessage',
+        ['subject_id', 'last_sent_at'],
+        unique=False
+    )
+
+
+def downgrade():
+    op.drop_index('idx_ka_message_subject_sent', table_name='TbKaMessage')

--- a/models/tb_ka_message.py
+++ b/models/tb_ka_message.py
@@ -1,5 +1,5 @@
 import uuid
-from sqlalchemy import Column, String, DateTime, BigInteger, Integer, Text, Float
+from sqlalchemy import Column, String, DateTime, BigInteger, Integer, Text, Float, Index, desc
 
 from util.date_tool import get_seoul_time
 from util.database import Base
@@ -7,6 +7,10 @@ from util.database import Base
 
 class TbKaMessage(Base):
     __tablename__ = "TbKaMessage"
+
+    __table_args__ = (
+        Index("idx_ka_message_subject_sent", "subject_id", desc("last_sent_at")),
+    )
 
     id = Column(String(32), primary_key=True, default=lambda: str(uuid.uuid4()).replace('-', ''))
     chat_id = Column(BigInteger, nullable=False)


### PR DESCRIPTION
### 변경사항
- Alembic migration 파일 추가: `ff1b46e7d6bd_add_index_to_subject_id_and_last_sent_.py`
- TbKaMessage 테이블에 복합 인덱스 `idx_ka_message_subject_sent` 생성
→ `(subject_id, last_sent_at DESC)` 기준
- `README.md` 에 `Alembic migration` 단계 추가

### 목적
- 최근 메시지 조회 쿼리의 성능 향상
→ `subject_id` 별로 메시지를 빠르게 찾기 위한 인덱스 최적화

### 참고사항
- 새로운 서버에서는 반드시 다음 명령어로 마이그레이션 적용 필요
  ```bash
  alembic upgrade head
  ```
  
### 관련 이슈
close #24 