### PR TITLE
[FEAT] TbSubject 테이블에 is_tag_assigned 컬럼 추가 및 ORM 모델 수정

### DIFF
--- a/alembic/versions/67245a85d47a_fix_deleted_column_to_char_1_and_set_.py
+++ b/alembic/versions/67245a85d47a_fix_deleted_column_to_char_1_and_set_.py
@@ -1,0 +1,60 @@
+"""fix deleted column to CHAR(1) and set default for is_tag_assigned and fix TbKaMessage.similar_id and TbKaMessage.id column to CHAR(32)
+
+Revision ID: 67245a85d47a
+Revises: e5492ed75525
+Create Date: 2025-04-28 21:18:10.677140
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision: str = '67245a85d47a'
+down_revision: Union[str, None] = 'e5492ed75525'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column('TbKaMessage', 'id',
+               existing_type=mysql.VARCHAR(length=32),
+               type_=sa.CHAR(length=32),
+               existing_nullable=False)
+    op.alter_column('TbKaMessage', 'similar_id',
+               existing_type=mysql.VARCHAR(length=32),
+               type_=sa.CHAR(length=32),
+               existing_nullable=False)
+    op.alter_column('TbKaMessage', 'deleted',
+               existing_type=mysql.VARCHAR(length=1),
+               type_=sa.CHAR(length=1),
+               existing_nullable=True)
+    op.drop_index('idx_ka_message_subject_sent', table_name='TbKaMessage')
+    op.create_index('idx_ka_message_subject_sent', 'TbKaMessage', ['subject_id', sa.text('last_sent_at DESC')], unique=False)
+    op.alter_column('TbSubject', 'deleted',
+               existing_type=mysql.VARCHAR(length=1),
+               type_=sa.CHAR(length=1),
+               existing_nullable=True)
+
+
+def downgrade() -> None:
+    op.alter_column('TbSubject', 'deleted',
+               existing_type=sa.CHAR(length=1),
+               type_=mysql.VARCHAR(length=1),
+               existing_nullable=True)
+    op.drop_index('idx_ka_message_subject_sent', table_name='TbKaMessage')
+    op.create_index('idx_ka_message_subject_sent', 'TbKaMessage', ['subject_id', 'last_sent_at'], unique=False)
+    op.alter_column('TbKaMessage', 'deleted',
+               existing_type=sa.CHAR(length=1),
+               type_=mysql.VARCHAR(length=1),
+               existing_nullable=True)
+    op.alter_column('TbKaMessage', 'similar_id',
+               existing_type=sa.CHAR(length=32),
+               type_=mysql.VARCHAR(length=32),
+               existing_nullable=False)
+    op.alter_column('TbKaMessage', 'id',
+               existing_type=sa.CHAR(length=32),
+               type_=mysql.VARCHAR(length=32),
+               existing_nullable=False)

--- a/alembic/versions/e5492ed75525_add_is_tag_assigned_column_to_tbsubject.py
+++ b/alembic/versions/e5492ed75525_add_is_tag_assigned_column_to_tbsubject.py
@@ -1,0 +1,52 @@
+"""add is_tag_assigned column to TbSubject
+
+Revision ID: e5492ed75525
+Revises: ff1b46e7d6bd
+Create Date: 2025-04-28 20:41:36.432397
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision: str = 'e5492ed75525'
+down_revision: Union[str, None] = 'ff1b46e7d6bd'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column('TbKaMessage', 'similar_id',
+               existing_type=mysql.VARCHAR(length=32),
+               nullable=False)
+    op.alter_column('TbKaMessage', 'deleted',
+               existing_type=mysql.CHAR(length=1),
+               type_=sa.String(length=1),
+               existing_nullable=True)
+
+    op.create_index('idx_ka_message_subject_sent', 'TbKaMessage', ['subject_id', sa.text('last_sent_at DESC')], unique=False)
+    op.add_column('TbSubject', sa.Column('is_tag_assigned', sa.Boolean(), nullable=True))
+    op.alter_column('TbSubject', 'deleted',
+               existing_type=mysql.VARCHAR(length=255),
+               type_=sa.String(length=1),
+               existing_nullable=True)
+
+
+def downgrade() -> None:
+    op.alter_column('TbSubject', 'deleted',
+               existing_type=sa.String(length=1),
+               type_=mysql.VARCHAR(length=255),
+               existing_nullable=True)
+    op.drop_column('TbSubject', 'is_tag_assigned')
+    op.drop_index('idx_ka_message_subject_sent', table_name='TbKaMessage')
+    op.create_index('idx_ka_message_subject_sent', 'TbKaMessage', ['subject_id', 'last_sent_at'], unique=False)
+    op.alter_column('TbKaMessage', 'deleted',
+               existing_type=sa.String(length=1),
+               type_=mysql.CHAR(length=1),
+               existing_nullable=True)
+    op.alter_column('TbKaMessage', 'similar_id',
+               existing_type=mysql.VARCHAR(length=32),
+               nullable=True)

--- a/models/tb_ka_message.py
+++ b/models/tb_ka_message.py
@@ -1,5 +1,5 @@
 import uuid
-from sqlalchemy import Column, String, DateTime, BigInteger, Integer, Text, Float, Index, desc
+from sqlalchemy import Column, DateTime, BigInteger, Integer, Text, Float, Index, desc, CHAR
 
 from util.date_tool import get_seoul_time
 from util.database import Base
@@ -12,7 +12,7 @@ class TbKaMessage(Base):
         Index("idx_ka_message_subject_sent", "subject_id", desc("last_sent_at")),
     )
 
-    id = Column(String(32), primary_key=True, default=lambda: str(uuid.uuid4()).replace('-', ''))
+    id = Column(CHAR(32), primary_key=True, default=lambda: str(uuid.uuid4()).replace('-', ''))
     chat_id = Column(BigInteger, nullable=False)
     client_message_id = Column(BigInteger, nullable=False)
     room_id = Column(BigInteger, nullable=False)
@@ -20,9 +20,9 @@ class TbKaMessage(Base):
     message = Column(Text, nullable=False)
     distance = Column(Float, nullable=False)
     threshold = Column(Float, nullable=False)
-    similar_id = Column(String(32), nullable=False)
+    similar_id = Column(CHAR(32), nullable=False)
     created_at = Column(DateTime, default=get_seoul_time)
     updated_at = Column(DateTime, default=get_seoul_time, onupdate=get_seoul_time)
     last_sent_at = Column(Integer)
-    deleted = Column(String(1), default="N")
+    deleted = Column(CHAR(1), default="N")
     subject_id = Column(BigInteger, nullable=False)

--- a/models/tb_subject.py
+++ b/models/tb_subject.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, DateTime, BigInteger, Integer
+from sqlalchemy import Column, DateTime, BigInteger, Integer, Boolean, CHAR
 from util.database import Base
 from util.date_tool import get_seoul_time
 
@@ -10,6 +10,7 @@ class TbSubject(Base):
     updated_at = Column(DateTime, default=get_seoul_time, onupdate=get_seoul_time)
     last_sent_at = Column(Integer)
     last_sent_chat_id = Column(BigInteger)
-    deleted = Column(String(1), default="N")
+    deleted = Column(CHAR(1), default="N")
+    is_tag_assigned = Column(Boolean, default=False, server_default="0")
     # priority_value
     # is_ban


### PR DESCRIPTION
## 주요 변경사항
•	TbSubject 테이블에 is_tag_assigned 컬럼 추가 (tinyint(1), default = false)
•	SQLAlchemy 모델(TbSubject)에 is_tag_assigned 필드 추가
•	Alembic migration 파일 생성 및 적용

## 배경
•	Tag 자동 할당 여부를 저장하기 위해 is_tag_assigned 컬럼이 필요했습니다.

## 추가 참고사항
•	Alembic을 통한 migration이 필요합니다. (alembic upgrade head)

## 관련 이슈
https://github.com/handong-app/handong-feed-app/issues/84
https://github.com/handong-app/handong-feed-app/issues/142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - TbSubject에 태그 할당 여부를 나타내는 새로운 Boolean 컬럼(is_tag_assigned)이 추가되었습니다.

- **버그 수정**
    - TbKaMessage와 TbSubject의 deleted 컬럼 타입이 CHAR(1)으로 변경되어 데이터 일관성이 향상되었습니다.
    - TbKaMessage의 id, similar_id 컬럼이 CHAR(32) 타입으로 변경되었습니다.

- **기타**
    - 일부 인덱스가 last_sent_at 컬럼의 내림차순 정렬을 포함하도록 재구성되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->