### PR TITLE
[BUG] YAML parsing issue in issue template (follow-up to #27)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,4 +3,4 @@ blank_issues_enabled: false  # "빈 이슈 만들기" 버튼 비활성화
 contact_links:
   - name: 📄 한동피드 관련 문의 및 피드백
     url: https://board.handong.app/feed/num/19
-    about: 한동피드 관련 문의사항 및 피드백이 있으시면 '문의사항 등록 방법'을 참고해주세요.
+    about: "한동피드 관련 문의사항 및 피드백이 있으시면 '문의사항 등록 방법'을 참고해주세요."


### PR DESCRIPTION
## 📌 관련 이슈  
<!-- 닫을 이슈 번호를 명시해주세요 -->  
Follow-up to #123 ← 이전 머지된 PR 번호로 바꿔주세요

___

## ✨ 작업 내용  
<!-- 이번 PR에서 어떤 작업을 했는지 간략히 설명해주세요 -->
- 이슈 템플릿의 `about` 필드에서 YAML 파싱 오류 가능성 수정
- 단일 인용부호(`'`) 포함된 문자열을 큰따옴표로 감싸 안정성 확보

___

## 🔎 세부 설명  
<!-- 구현 내용에 관해 구체적으로 적어주세요 -->
- YAML 문법상 `'` 문자가 포함된 문자열은 큰따옴표로 감싸지 않으면 파싱 오류 발생 가능
- 실제 사용 환경(GitHub UI 등)에서 렌더링 문제를 방지하기 위해 보완
- 기존 템플릿 기능 및 형식에는 변화 없음

___

## 🧪 테스트  
<!-- 테스트한 내용이나 테스트 방법을 구체적으로 적어주세요 -->
- [x] PR 브랜치 기준으로 이슈 템플릿 렌더링 정상 작동 확인
- [x] YAML 문법 검사 통과
- [x] 기존 이슈 템플릿 항목 및 구조 유지 확인

___

## 📁 변경된 파일/폴더  
<!-- 변경된 주요 파일 경로나 구조가 있다면 정리해주세요 -->
- `.github/ISSUE_TEMPLATE/other.md`

___

## ➕ 기타  
<!-- 추가적으로 작성할 내용이 있다면 적어주세요 -->
- 이후에도 YAML 템플릿 수정 시, 따옴표 사용에 주의 필요